### PR TITLE
Ds share vision

### DIFF
--- a/ironfist/ironfist/ironfist.vcxproj.user
+++ b/ironfist/ironfist/ironfist.vcxproj.user
@@ -4,4 +4,7 @@
     <LocalDebuggerWorkingDirectory>$(ProjectDir)..\bin</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
+  <PropertyGroup>
+    <ShowAllFiles>true</ShowAllFiles>
+  </PropertyGroup>
 </Project>

--- a/ironfist/ironfist/ironfist.vcxproj.user
+++ b/ironfist/ironfist/ironfist.vcxproj.user
@@ -4,7 +4,4 @@
     <LocalDebuggerWorkingDirectory>$(ProjectDir)..\bin</LocalDebuggerWorkingDirectory>
     <DebuggerFlavor>WindowsLocalDebugger</DebuggerFlavor>
   </PropertyGroup>
-  <PropertyGroup>
-    <ShowAllFiles>true</ShowAllFiles>
-  </PropertyGroup>
 </Project>

--- a/ironfist/src/cpp/adventure/adv.cpp
+++ b/ironfist/src/cpp/adventure/adv.cpp
@@ -87,7 +87,7 @@ mapCell* advManager::MoveHero(int a2, int a3, int *a4, int *a5, int *a6, int a7,
 }
 
 void game::ShareVision(int sourcePlayer, int destPlayer) {
-  this->sharePlayerVision[sourcePlayer][destPlayer] = 1;
+  this->sharePlayerVision[sourcePlayer][destPlayer] = true;
   this->PropagateVision();
 }
 

--- a/ironfist/src/cpp/game/game.cpp
+++ b/ironfist/src/cpp/game/game.cpp
@@ -83,7 +83,7 @@ void game::PerDay() {
 void game::ResetIronfistGameState() {
     for (int i = 0; i < NUM_PLAYERS; i++) {
         for (int j = 0; j < NUM_PLAYERS; j++) {
-            this->sharePlayerVision[i][j] = 0;
+            this->sharePlayerVision[i][j] = false;
         }
     }
 }

--- a/ironfist/src/cpp/game/save.cpp
+++ b/ironfist/src/cpp/game/save.cpp
@@ -302,6 +302,8 @@ void game::LoadGame(char* filnam, int newGame, int a3) {
 	if(newGame) {
 		this->SetupOrigData();
 
+		gpGame->ResetIronfistGameState();
+
 		for(int i = 0; i < MAX_HEROES; i++) {
 			//SetupOrigData clears out spellsLearned. Of course, we've changed
 			//spellsLearned from an array to a pointer, so that actually NULLs it out


### PR DESCRIPTION
I left a long series of notes while working on this in the Trello card for "ShareVision". I suggest looking at these briefly, but I want to note here that I was able to force the "ShareVision" function to fail in one save, at first, but I can no longer produce such a failure. I had previously thought that there might have been an issue with the way that the matrix was stored, but apparently that's stored with the save files as well. Somehow, the one time that produced a failure has somehow acquired the data representing the matrix with all "false" elements after previously having a functioning "ShareVision" and "PropagateVision" such that they would reveal the enemy tiles. After quite a bit of testing, I am no longer able to produce this effect. So, as far as I know, the "ShareVision" function now works! Now I'll just be forced to ponder the ramifications of my anomaly.
