### PR TITLE
Fixed the crash on delete hero

### DIFF
--- a/src/cpp/editor/map_state.cpp
+++ b/src/cpp/editor/map_state.cpp
@@ -8,7 +8,7 @@ extern unsigned __int16 gpEventDataIndices[];
 extern int __fastcall HasExtraObjectData(int);
 
 void __fastcall DeleteExtraObjectData(unsigned int idx) {
-	BaseFree(gpEditManager->mapExtra[idx], __FILE__ , __LINE__);
+	FREE(gpEditManager->mapExtra[idx]);
 
     if (gpEditManager->nMapExtra > idx + 1) {
         memmove(

--- a/src/cpp/editor/map_state.cpp
+++ b/src/cpp/editor/map_state.cpp
@@ -8,7 +8,7 @@ extern unsigned __int16 gpEventDataIndices[];
 extern int __fastcall HasExtraObjectData(int);
 
 void __fastcall DeleteExtraObjectData(unsigned int idx) {
-    delete gpEditManager->mapExtra[idx];
+	BaseFree(gpEditManager->mapExtra[idx], __FILE__ , __LINE__);
 
     if (gpEditManager->nMapExtra > idx + 1) {
         memmove(


### PR DESCRIPTION
This prevents the crash, but adding a hero later on may possible crash the game when the map is loaded again. The cause is unknown