### PR TITLE
Changed default target folder to "GOG Games"

### DIFF
--- a/installer/ironfist.nsi
+++ b/installer/ironfist.nsi
@@ -1,7 +1,7 @@
 outfile "ironfist-install.exe"
 Name "Project Ironfist"
 
-installDir "C:\GOG Games\Heroes of Might and Magic 2 GOLD"
+installDir "C:\GOG Games\"
 
 Page directory
 Page instfiles


### PR DESCRIPTION
This really just forces users to select the correct folder while keeping
the installer from making a new subfolder under the name of the default
path folder, as it realizes that it is already in that folder;
therefore, it simply chooses the selected folder as the target folder,
instead of creating a subfolder within the selected folder.