### PR TITLE
Optionally disable +2 growth from the well.

### DIFF
--- a/src/asm/heroes2_imports.inc
+++ b/src/asm/heroes2_imports.inc
@@ -83,6 +83,8 @@ IMPORT_?AddManager@executive@@QAEHPAVbaseManager@@H@Z = 1
 ;;init
 IMPORT_?InitMainClasses@@YIXXZ = 1
 IMPORT_?DeleteMainClasses@@YIXXZ = 1
+IMPORT_?InterpretCommandLine@@YIHXZ = 1
+?InterpretCommandLine@@YIHXZ_clone EQU ?InterpretCommandLine_orig@@YIHXZ
 
 ;;allowing play without CD
 IMPORT_?SetupCDDrive@@YIHXZ = 1
@@ -285,16 +287,24 @@ IMPORT_?gTownEligibleBuildMask@@3PAKA = 1
 
 IMPORT_?SetupTowns@game@@QAEXXZ = 1
 IMPORT_?SetupMage@townManager@@QAEXPAVheroWindow@@@Z = 1
+IMPORT_?SetupWell@townManager@@QAEXPAVheroWindow@@@Z = 1
+?SetupWell@townManager@@QAEXPAVheroWindow@@@Z_clone EQU ?SetupWell_orig@townManager@@QAEXPAVheroWindow@@@Z
 IMPORT_?RecruitHero@townManager@@QAEHHH@Z = 1
 ?RecruitHero@townManager@@QAEHHH@Z_clone EQU ?RecruitHero_orig@townManager@@QAEHHH@Z
 IMPORT_?GetBuildingName@@YIPADHH@Z = 1
 ?Open@townManager@@UAEHH@Z_clone EQU ?Open_orig@townManager@@QAEHH@Z ; Changing U to Q changes virtual method to non
 IMPORT_?Open@recruitUnit@@UAEHH@Z = 1
 ?Open@recruitUnit@@UAEHH@Z_clone EQU ?Open_orig@recruitUnit@@QAEHH@Z
+IMPORT_?GetBuildingInfo@@YIPADHHH@Z = 1
+?GetBuildingInfo@@YIPADHHH@Z_clone EQU ?GetBuildingInfo_orig@@YIPADHHH@Z
 
 ;;scripting hooks
 IMPORT_?PerDay@game@@QAEXXZ = 1
 ?PerDay@game@@QAEXXZ_clone EQU ?PerDay_orig@game@@QAEXXZ
+IMPORT_?PerWeek@game@@QAEXXZ = 1
+?PerWeek@game@@QAEXXZ_clone EQU ?PerWeek_orig@game@@QAEXXZ
+IMPORT_?PerMonth@game@@QAEXXZ = 1
+?PerMonth@game@@QAEXXZ_clone EQU ?PerMonth_orig@game@@QAEXXZ
 IMPORT_?Open@advManager@@UAEHH@Z = 1
 ?Open@advManager@@UAEHH@Z_clone EQU ?Open_orig@advManager@@QAEHH@Z ; Changing U to Q changes virtual method to non
 IMPORT_?Open@townManager@@UAEHH@Z = 1

--- a/src/asm/heroes2_imports.inc
+++ b/src/asm/heroes2_imports.inc
@@ -83,8 +83,6 @@ IMPORT_?AddManager@executive@@QAEHPAVbaseManager@@H@Z = 1
 ;;init
 IMPORT_?InitMainClasses@@YIXXZ = 1
 IMPORT_?DeleteMainClasses@@YIXXZ = 1
-IMPORT_?InterpretCommandLine@@YIHXZ = 1
-?InterpretCommandLine@@YIHXZ_clone EQU ?InterpretCommandLine_orig@@YIHXZ
 
 ;;allowing play without CD
 IMPORT_?SetupCDDrive@@YIHXZ = 1

--- a/src/cpp/shared/combat/creatures.h
+++ b/src/cpp/shared/combat/creatures.h
@@ -131,6 +131,8 @@ enum CREATURE_EVENT_CODE {
 #define SHADOW_MARK "shadow-mark"
 #define JUMPER "jumper"
 
+extern char *speedText[];
+
 struct tag_monsterInfo
 {
   __int16 cost;

--- a/src/cpp/shared/game/game.cpp
+++ b/src/cpp/shared/game/game.cpp
@@ -159,8 +159,7 @@ void game::PerWeek() {
       const int dwellingIdx = d - BUILDING_DWELLING_1;
       if (townObj.ownerIdx >= 0) {
         townObj.numCreaturesInDwelling[dwellingIdx] -= 2;
-      }
-      else {
+      } else {
         townObj.numCreaturesInDwelling[dwellingIdx] -= 1;
       }
     }

--- a/src/cpp/shared/game/game.h
+++ b/src/cpp/shared/game/game.h
@@ -247,8 +247,8 @@ void __fastcall CheckEndGame(int a, int b);
 
 int __fastcall HandleAppSpecificMenuCommands(int a1);
 int __fastcall HandleAppSpecificMenuCommands_orig(int a1);
-int __fastcall InterpretCommandLine();
-int __fastcall InterpretCommandLine_orig();
+
+bool IsWellDisabled();
 
 extern game* gpGame;
 extern int gbInCampaign;
@@ -275,8 +275,6 @@ extern char xIsPlayingExpansionCampaign;
 extern int giCurTurn;
 extern int giMonthType;
 extern int giMonthTypeExtra;
-extern char gcCommandLine[];
-extern bool gbDisableWell;
 
 extern randomHeroCreatureInfo randomHeroArmyBounds[NUM_FACTIONS][2];
 extern int neutralTownCreatureTypes[NUM_FACTIONS][5];

--- a/src/cpp/shared/game/game.h
+++ b/src/cpp/shared/game/game.h
@@ -196,6 +196,10 @@ public:
 
 	void PerDay();
 	void PerDay_orig();
+  void PerWeek();
+  void PerWeek_orig();
+  void PerMonth();
+  void PerMonth_orig();
 
   void ResetIronfistGameState();
   void ShareVision(int sourcePlayer, int destPlayer);
@@ -243,6 +247,8 @@ void __fastcall CheckEndGame(int a, int b);
 
 int __fastcall HandleAppSpecificMenuCommands(int a1);
 int __fastcall HandleAppSpecificMenuCommands_orig(int a1);
+int __fastcall InterpretCommandLine();
+int __fastcall InterpretCommandLine_orig();
 
 extern game* gpGame;
 extern int gbInCampaign;
@@ -267,6 +273,10 @@ extern signed char gcColorToSetupPos[];
 extern signed char giVisRange[];
 extern char xIsPlayingExpansionCampaign;
 extern int giCurTurn;
+extern int giMonthType;
+extern int giMonthTypeExtra;
+extern char gcCommandLine[];
+extern bool gbDisableWell;
 
 extern randomHeroCreatureInfo randomHeroArmyBounds[NUM_FACTIONS][2];
 extern int neutralTownCreatureTypes[NUM_FACTIONS][5];

--- a/src/cpp/shared/gui/gui.h
+++ b/src/cpp/shared/gui/gui.h
@@ -95,7 +95,7 @@ void GUIAddFlag(heroWindow*, int, int);
 void GUIRemoveFlag(heroWindow*, int, int);
 void GUISetImgIdx(heroWindow*, int, int);
 void GUISetIcon(heroWindow*, int, char*);
-void GUISetText(heroWindow*, int, char*);
+void GUISetText(heroWindow*, int, const char*);
 void GUIDroplistAdd(heroWindow*, int, char*);
 
 void GUIBroadcastMessage(heroWindow*, int, int, void*);

--- a/src/cpp/shared/gui/gui.h
+++ b/src/cpp/shared/gui/gui.h
@@ -3,6 +3,7 @@
 
 #include "manager.h"
 #include "resource/resources.h"
+#include <string>
 
 #pragma pack(push,1)
 
@@ -95,8 +96,11 @@ void GUIAddFlag(heroWindow*, int, int);
 void GUIRemoveFlag(heroWindow*, int, int);
 void GUISetImgIdx(heroWindow*, int, int);
 void GUISetIcon(heroWindow*, int, char*);
-void GUISetText(heroWindow*, int, const char*);
+void GUISetIcon(heroWindow*, int, std::string&);
+void GUISetText(heroWindow*, int, char*);
+void GUISetText(heroWindow*, int, std::string&);
 void GUIDroplistAdd(heroWindow*, int, char*);
+void GUIDroplistAdd(heroWindow*, int, std::string&);
 
 void GUIBroadcastMessage(heroWindow*, int, int, void*);
 int GUIGetDropdownSelection(heroWindow*, void*);

--- a/src/cpp/shared/gui/msg.cpp
+++ b/src/cpp/shared/gui/msg.cpp
@@ -18,7 +18,7 @@ void GUISetIcon(heroWindow* hwnd, int f, char* p) {
 	GUIBroadcastMessage(hwnd, f, GUI_MESSAGE_SET_ICON, (void*)p);
 }
 
-void GUISetText(heroWindow* hwnd, int f, char* p) {
+void GUISetText(heroWindow* hwnd, int f, const char* p) {
 	GUIBroadcastMessage(hwnd, f, GUI_MESSAGE_SET_TEXT, (void*)p);
 }
 

--- a/src/cpp/shared/gui/msg.cpp
+++ b/src/cpp/shared/gui/msg.cpp
@@ -18,12 +18,24 @@ void GUISetIcon(heroWindow* hwnd, int f, char* p) {
 	GUIBroadcastMessage(hwnd, f, GUI_MESSAGE_SET_ICON, (void*)p);
 }
 
-void GUISetText(heroWindow* hwnd, int f, const char* p) {
+void GUISetIcon(heroWindow* hwnd, int f, std::string& p) {
+  GUISetIcon(hwnd, f, &p[0]);
+}
+
+void GUISetText(heroWindow* hwnd, int f, char* p) {
 	GUIBroadcastMessage(hwnd, f, GUI_MESSAGE_SET_TEXT, (void*)p);
+}
+
+void GUISetText(heroWindow* hwnd, int f, std::string& p) {
+  GUISetText(hwnd, f, &p[0]);
 }
 
 void GUIDroplistAdd(heroWindow* hwnd, int f, char* p) {
   GUIBroadcastMessage(hwnd, f, GUI_MESSAGE_DROPLIST_ADD, (void*)p);
+}
+
+void GUIDroplistAdd(heroWindow* hwnd, int f, std::string& p) {
+  GUIDroplistAdd(hwnd, f, &p[0]);
 }
 
 

--- a/src/cpp/shared/town/town.cpp
+++ b/src/cpp/shared/town/town.cpp
@@ -301,7 +301,7 @@ void townManager::SetupMage(heroWindow *mageGuildWindow) {
 
 void townManager::SetupWell(heroWindow *window) {
   SetupWell_orig(window);
-  if (!gbDisableWell) {
+  if (!IsWellDisabled()) {
     return;
   }
 
@@ -360,7 +360,7 @@ char *__fastcall GetBuildingName(int faction, int building) {
       return gSpecialBuildingNames[faction];
     } else if (building >= BUILDING_DWELLING_1) {
       return gDwellingNames[faction][building - BUILDING_DWELLING_1];
-    } else if (gbDisableWell && faction == FACTION_NECROMANCER && building == BUILDING_WELL) {
+    } else if (IsWellDisabled() && faction == FACTION_NECROMANCER && building == BUILDING_WELL) {
       static std::string poisonedWellName = "Poisoned Well";
       return &poisonedWellName[0];
     } else {
@@ -370,7 +370,7 @@ char *__fastcall GetBuildingName(int faction, int building) {
 }
 
 char * __fastcall GetBuildingInfo(int faction, int building, int withTitle) {
-  if (gbDisableWell && building == BUILDING_WELL) {
+  if (IsWellDisabled() && building == BUILDING_WELL) {
     static std::string buf;
     std::string wellInfo = "The Well provides refreshing drinking water.";
     if (faction == FACTION_NECROMANCER) {

--- a/src/cpp/shared/town/town.cpp
+++ b/src/cpp/shared/town/town.cpp
@@ -327,7 +327,7 @@ void townManager::SetupWell(heroWindow *window) {
 
     // Overwrite the text the original code sent for each creature's
     // description field in the Well window.
-    GUISetText(window, 25 + tier, desc.str().c_str());
+    GUISetText(window, 25 + tier, desc.str());
   }
 }
 

--- a/src/cpp/shared/town/town.h
+++ b/src/cpp/shared/town/town.h
@@ -66,6 +66,7 @@ enum BUILDING_CODE : __int8
   BUILDING_UPGRADE_5 = 0x1D,
   BUILDING_UPGRADE_5B = 0x1E,
   BUILDING_EXT_3 = 0x1F,
+  BUILDING_MAX
 };
 
 class town {
@@ -102,6 +103,13 @@ public:
   void SetNumSpellsOfLevel(int,int);
 
   void BuildBuilding(int);
+  bool BuildingBuilt(int) const;
+  bool DwellingBuilt(int) const;
+
+  // Get the index of the most upgraded building built at the given tier.
+  // Returns integer in range [0, NUM_DWELLINGS), or -1 for an invalid
+  // tier outside range [0, 5].
+  int DwellingIndex(int) const;
 };
 
 class townManager : public baseManager {
@@ -115,6 +123,8 @@ public:
 	virtual int Open(int);
 	int Open_orig(int);
 	void SetupMage(heroWindow*);
+	void SetupWell(heroWindow*);
+	void SetupWell_orig(heroWindow*);
 
 	int RecruitHero(int,int);
 	int RecruitHero_orig(int,int);
@@ -152,8 +162,10 @@ extern char *gSpecialBuildingNames[];
 extern char *gNeutralBuildingNames[];
 extern char *gDwellingNames[][12];
 
-int BuildingBuilt(town*, int);
 char *__fastcall GetBuildingName(int faction, int building);
+char * __fastcall GetBuildingInfo(int faction, int building, int withTitle);
+char * __fastcall GetBuildingInfo_orig(int faction, int building, int withTitle);
+
 
 extern townManager* gpTownManager;
 


### PR DESCRIPTION
Creating a clean pull request by combining several changes:
- change Well description to not mention +2 growth
- rename Well to Poisoned Well in Necromancer castle, for flavor
- undo +2 growth per week
- disable month of the plague
- update Well window creature descriptions with corrected growth rates
- added `/disable-well` command line option