### PR TITLE
Add cursed item support to artifacts.xml

### DIFF
--- a/data/artifacts.xml
+++ b/data/artifacts.xml
@@ -73,7 +73,7 @@
         <description>The Medal of Distinction increases your morale.</description>
         <event>Ridding the countryside of the hideous Minotaur who made a sport of eating noblemen's Knights, you are honored with the Medal of Distinction.</event>
     </artifact>
-    <artifact id="16" name="Fizbin of Misfortune" level="treasure">
+    <artifact id="16" name="Fizbin of Misfortune" level="treasure" cursed="true">
         <title>Fizbin</title>
         <description>The Fizbin of Misfortune greatly decreases your morale.</description>
         <event>You stumble upon a medal lying alongside the empty road.  Adding the medal to your inventory, you become aware that you have acquired the undesirable Fizbin of Misfortune, greatly decreasing your army's morale.</event>
@@ -338,12 +338,12 @@
         <description>The Ammo Cart provides endless ammunition for all your troops that shoot.</description>
         <event>An ammunition cart in the middle of an old battlefield catches your eye.  Inspection shows it to be in good working order, so  you take it along.</event>
     </artifact>
-    <artifact id="69" name="Tax Lien" level="treasure">
+    <artifact id="69" name="Tax Lien" level="treasure" cursed="true">
         <title>Tax lien</title>
         <description>The Tax Lien costs you 250 gold pieces/turn.</description>
         <event>Your big spending habits have earned you a massive tax bill that you can't hope to pay.  The tax man takes pity and agrees to only take 250 gold a day from your account for life.  Check here if you want one dollar to go to the presidential campaign election fund.</event>
     </artifact>
-    <artifact id="70" name="Hideous Mask" level="treasure">
+    <artifact id="70" name="Hideous Mask" level="treasure" cursed="true">
         <title>Hideous mask</title>
         <description>The Hideous Mask prevents all 'wandering' armies from joining your hero.</description>
         <event>Your looting of the grave of Sinfilas Gardolad, the famous shapeshifting Warlock, unearths his fabled mask.  Trembling, you put it on and it twists your visage into an awful grimace!  Oh no!  It's actually the hideous mask of Gromluck Greene, and you are stuck with it.</event>
@@ -427,7 +427,7 @@
         <description>This Spell Scroll gives your hero the ability to cast the '%s' spell.</description>
         <event>You find an elaborate container which houses an old vellum scroll. The runes on the container are very old, and the artistry with which it was put together is stunning. As you pull the scroll out, you feel imbued with magical power.</event>
     </artifact>
-    <artifact id="87" name="Arm of the Martyr" level="treasure">
+    <artifact id="87" name="Arm of the Martyr" level="treasure" cursed="true">
         <title>Arm of the Martyr</title>
         <description>The Arm of the Martyr increases your spell power by 3 but adds the undead morale penalty.</description>
         <event>One of the less intelligent members of your party picks up an arm off of the ground.  Despite its missing a body, it is still moving.  Your troops find the dismembered arm repulsive, but you cannot bring yourself to drop it: it seems to hold some sort of magical power that influences your decision making.</event>
@@ -437,7 +437,7 @@
         <description>The Breastplate increases your defense by 5.</description>
         <event>You come upon a sign.  It reads: "Here lies the body of Anduran.  Bow and swear fealty, and you shall be rewarded."  You decide to do as it says.  As you stand up, you feel a coldness against your skin.  Looking down, you find that you are suddenly wearing a gleaming, ornate breastplate.</event>
     </artifact>
-    <artifact id="89" name="Broach of Shielding" level="treasure">
+    <artifact id="89" name="Broach of Shielding" level="treasure" cursed="true">
         <title>Broach of Shielding</title>
         <description>The Broach of Shielding provides 50% protection from Armageddon and Elemental Storm, but decreases spell power by 2.</description>
         <event>A kindly Sorceress thinks that your army's defenses could use a magical boost.  She offers to enchant the Broach that you wear on your cloak, and you accept.</event>
@@ -452,12 +452,12 @@
         <description>The Crystal Ball lets you get more specific information about monsters, enemy heroes, and castles nearby the hero who holds it.</description>
         <event>You come upon a caravan of gypsies who are feasting and fortifying their bodies with mead.  They call you forward and say "If you prove that you can dance the Rama-Buta, we will reward you."  You don't know it, but try anyway.  They laugh hysterically, but admire your bravery, giving you a Crystal Ball.</event>
     </artifact>
-    <artifact id="92" name="Heart of Fire" level="treasure">
+    <artifact id="92" name="Heart of Fire" level="treasure" cursed="true">
         <title>Heart of Fire</title>
         <description>The Heart of Fire provides 50% protection from fire, but doubles the damage taken from cold.</description>
         <event>You enter a recently burned glade and come upon a Fire Elemental sitting atop a rock.  It looks up, its flaming face contorted in a look of severe pain.  It then tosses a glowing object at you.  You put up your hands to block it, but it passes right through them and sears itself into your chest.</event>
     </artifact>
-    <artifact id="93" name="Heart of Ice" level="treasure">
+    <artifact id="93" name="Heart of Ice" level="treasure" cursed="true">
         <title>Heart of Ice</title>
         <description>The Heart of Ice provides 50% protection from cold, but doubles the damage taken from fire.</description>
         <event>Suddenly, a biting coldness engulfs your body.  You seize up, falling from your horse.  The pain subsides, but you still feel as if your chest is frozen.  As you pick yourself up off of the ground, you hear hearty laughter.  You turn around just in time to see a Frost Giant run off into the woods and disappear.</event>

--- a/installer/ironfist.nsi
+++ b/installer/ironfist.nsi
@@ -44,6 +44,8 @@ Section
 	File ..\build\ironfist.agg
 	File ..\src\xsd\creatures_xml.xsd
 	File ..\data\creatures.xml
+	File ..\src\xsd\artifacts_xml.xsd
+	File ..\data\artifacts.xml
 
 	SetOutPath $INSTDIR\GAMES
 
@@ -87,6 +89,8 @@ Section "uninstall"
 	Delete "$INSTDIR\DATA\ironfist.agg"
 	Delete "$INSTDIR\DATA\creatures_xml.xsd"
 	Delete "$INSTDIR\DATA\creatures.xml"
+	Delete "$INSTDIR\DATA\artifacts_xml.xsd"
+	Delete "$INSTDIR\DATA\artifacts.xml"
 
 	Delete "$INSTDIR\GAMES\map_xml.xsd"
 

--- a/src/asm/heroes2_imports.inc
+++ b/src/asm/heroes2_imports.inc
@@ -191,6 +191,7 @@ IMPORT_?gArtifactNames@@3PAPADA = 1
 IMPORT_?gArtifactDesc@@3PAPADA = 1
 IMPORT_?gArtifactEvents@@3PAPADA = 1
 IMPORT_?gArtifactLevel@@3PAEA = 1
+IMPORT_?IsCursedItem@@YIHH@Z = 1
 
 ;;combat
 IMPORT_?gCombatFxNames@@3PAPADA = 1

--- a/src/cpp/shared/artifacts.cpp
+++ b/src/cpp/shared/artifacts.cpp
@@ -70,6 +70,7 @@ unsigned char gArtifactLevel[NUM_SUPPORTED_ARTIFACTS] = { 0 };
 std::vector<std::string> names;
 std::vector<std::string> descriptions;
 std::vector<std::string> events;
+std::vector<char> isCursed;
 
 
 void LoadArtifacts() {
@@ -80,6 +81,7 @@ void LoadArtifacts() {
   names.resize(artSize);
   descriptions.resize(artSize);
   events.resize(artSize);
+  isCursed.resize(artSize, 0);
 
   for (const auto &art : artifactList) {
     const int i = art.id();
@@ -103,5 +105,18 @@ void LoadArtifacts() {
     gArtifactEvents[i] = &(events[i][0]);
 
     gArtifactLevel[i] = GetArtifactLevel(art.level());
+
+    if (art.cursed()) {
+      isCursed[i] = art.cursed().get();
+    }
   }
+}
+
+int __fastcall IsCursedItem(int artId) {
+  const int size = isCursed.size();
+  if (artId < 0 || artId >= size) {
+    return 0;
+  }
+
+  return isCursed[artId];
 }

--- a/src/cpp/shared/artifacts.h
+++ b/src/cpp/shared/artifacts.h
@@ -111,5 +111,6 @@ enum ARTIFACT {
 };
 
 void LoadArtifacts();
+int __fastcall IsCursedItem(int);
 
 #endif

--- a/src/cpp/shared/artifacts_xml.cxx
+++ b/src/cpp/shared/artifacts_xml.cxx
@@ -163,6 +163,30 @@ level (::std::auto_ptr< level_type > x)
   this->level_.set (x);
 }
 
+const artifact_t::cursed_optional& artifact_t::
+cursed () const
+{
+  return this->cursed_;
+}
+
+artifact_t::cursed_optional& artifact_t::
+cursed ()
+{
+  return this->cursed_;
+}
+
+void artifact_t::
+cursed (const cursed_type& x)
+{
+  this->cursed_.set (x);
+}
+
+void artifact_t::
+cursed (const cursed_optional& x)
+{
+  this->cursed_ = x;
+}
+
 
 // level_t
 // 
@@ -246,7 +270,8 @@ artifact_t (const id_type& id,
   event_ (::xml_schema::flags (), this),
   id_ (id, ::xml_schema::flags (), this),
   name_ (name, ::xml_schema::flags (), this),
-  level_ (level, ::xml_schema::flags (), this)
+  level_ (level, ::xml_schema::flags (), this),
+  cursed_ (::xml_schema::flags (), this)
 {
 }
 
@@ -260,7 +285,8 @@ artifact_t (const artifact_t& x,
   event_ (x.event_, f, this),
   id_ (x.id_, f, this),
   name_ (x.name_, f, this),
-  level_ (x.level_, f, this)
+  level_ (x.level_, f, this),
+  cursed_ (x.cursed_, f, this)
 {
 }
 
@@ -274,7 +300,8 @@ artifact_t (const ::xercesc::DOMElement& e,
   event_ (f, this),
   id_ (f, this),
   name_ (f, this),
-  level_ (f, this)
+  level_ (f, this),
+  cursed_ (f, this)
 {
   if ((f & ::xml_schema::flags::base) == 0)
   {
@@ -356,6 +383,12 @@ parse (::xsd::cxx::xml::dom::parser< char >& p,
         level_traits::create (i, f, this));
 
       this->level_.set (r);
+      continue;
+    }
+
+    if (n.name () == "cursed" && n.namespace_ ().empty ())
+    {
+      this->cursed_.set (cursed_traits::create (i, f, this));
       continue;
     }
   }
@@ -1056,6 +1089,18 @@ operator<< (::xercesc::DOMElement& e, const artifact_t& i)
         e));
 
     a << i.level ();
+  }
+
+  // cursed
+  //
+  if (i.cursed ())
+  {
+    ::xercesc::DOMAttr& a (
+      ::xsd::cxx::xml::dom::create_attribute (
+        "cursed",
+        e));
+
+    a << *i.cursed ();
   }
 }
 

--- a/src/cpp/shared/artifacts_xml.hxx
+++ b/src/cpp/shared/artifacts_xml.hxx
@@ -366,6 +366,24 @@ class artifact_t: public ::xml_schema::type
   void
   level (::std::auto_ptr< level_type > p);
 
+  // cursed
+  // 
+  typedef ::xml_schema::boolean cursed_type;
+  typedef ::xsd::cxx::tree::optional< cursed_type > cursed_optional;
+  typedef ::xsd::cxx::tree::traits< cursed_type, char > cursed_traits;
+
+  const cursed_optional&
+  cursed () const;
+
+  cursed_optional&
+  cursed ();
+
+  void
+  cursed (const cursed_type& x);
+
+  void
+  cursed (const cursed_optional& x);
+
   // Constructors.
   //
   artifact_t (const id_type&,
@@ -401,6 +419,7 @@ class artifact_t: public ::xml_schema::type
   ::xsd::cxx::tree::one< id_type > id_;
   ::xsd::cxx::tree::one< name_type > name_;
   ::xsd::cxx::tree::one< level_type > level_;
+  cursed_optional cursed_;
 };
 
 class level_t: public ::xml_schema::string

--- a/src/xsd/artifacts_xml.xsd
+++ b/src/xsd/artifacts_xml.xsd
@@ -18,6 +18,7 @@
         <xs:attribute name="id" type="xs:int" use="required" />
         <xs:attribute name="name" type="xs:string" use="required" />
         <xs:attribute name="level" type="level_t" use="required" />
+        <xs:attribute name="cursed" type="xs:boolean" use="optional" />
     </xs:complexType>
 
     <xs:simpleType name="level_t">


### PR DESCRIPTION
And a couple extras:

- include artifacts.xml in the installer
- removed a weird variable that pointed to the artifact name list, off by one index