### PR TITLE
Allow new artifacts to be generated randomly.

### DIFF
--- a/src/asm/heroes2_imports.inc
+++ b/src/asm/heroes2_imports.inc
@@ -192,6 +192,8 @@ IMPORT_?gArtifactDesc@@3PAPADA = 1
 IMPORT_?gArtifactEvents@@3PAPADA = 1
 IMPORT_?gArtifactLevel@@3PAEA = 1
 IMPORT_?IsCursedItem@@YIHH@Z = 1
+IMPORT_?InitRandomArtifacts@game@@QAEXXZ = 1
+IMPORT_?GetRandomArtifactId@game@@QAEHHH@Z = 1
 
 ;;combat
 IMPORT_?gCombatFxNames@@3PAPADA = 1

--- a/src/cpp/editor/editor.cpp
+++ b/src/cpp/editor/editor.cpp
@@ -4,6 +4,7 @@
 #include "artifacts.h"
 #include "base.h"
 #include "string.h"
+#include "game/game.h"
 #include "gui/gui.h"
 #include "gui/msg.h"
 #include "spell/spell_constants.h"
@@ -119,7 +120,7 @@ int __fastcall SpellScrollEditDialogCallback(tag_message& msg) {
 }
 
 int __cdecl WinConditionHandler() {
-  if (gpMapHeader.winConditionType != WIN_FIND_ARTIFACT) {
+  if (gpMapHeader.winConditionType != WIN_CONDITION_FIND_ARTIFACT) {
     return WinConditionHandler_orig();
   }
 
@@ -150,7 +151,7 @@ int __cdecl WinConditionHandler() {
 // Convert the index of the selected artifact from the droplist to the real
 // artifact id.
 int __fastcall FillInWinCondition(int index) {
-  if (gpMapHeader.winConditionType != WIN_FIND_ARTIFACT) {
+  if (gpMapHeader.winConditionType != WIN_CONDITION_FIND_ARTIFACT) {
     return FillInWinCondition_orig(index);
   }
 

--- a/src/cpp/shared/adventure/map.h
+++ b/src/cpp/shared/adventure/map.h
@@ -116,15 +116,6 @@ struct SMapHeader {
 	char numEvents;
 };
 
-enum WinConditionType {
-  WIN_STANDARD,
-  WIN_CAPTURE_CASTLE,
-  WIN_DEFEAT_HERO,
-  WIN_FIND_ARTIFACT,
-  WIN_TEAM,
-  WIN_ACCUMULATE_GOLD
-};
-
 extern int MAP_HEIGHT;
 extern int MAP_WIDTH;
 

--- a/src/cpp/shared/artifacts.cpp
+++ b/src/cpp/shared/artifacts.cpp
@@ -40,21 +40,21 @@ namespace {
     return ret;
   }
 
-  int GetArtifactLevel(level_t::value lvl) {
+  int GetLevel(level_t::value lvl) {
     switch (lvl) {
     case level_t::ultimate:
-      return 1;
+      return ARTIFACT_LEVEL_ULTIMATE;
     case level_t::major:
-      return 2;
+      return ARTIFACT_LEVEL_MAJOR;
     case level_t::minor:
-      return 4;
+      return ARTIFACT_LEVEL_MINOR;
     case level_t::treasure:
-      return 8;
+      return ARTIFACT_LEVEL_TREASURE;
     case level_t::spellbook:
-      return 16;
+      return ARTIFACT_LEVEL_SPELLBOOK;
     case level_t::unused:
     default:
-      return 32;
+      return ARTIFACT_LEVEL_UNUSED;
     }
   }
 
@@ -102,7 +102,7 @@ void LoadArtifacts() {
     events[i] = JoinSequence(art.event());
     gArtifactEvents[i] = &(events[i][0]);
 
-    gArtifactLevel[i] = GetArtifactLevel(art.level());
+    gArtifactLevel[i] = GetLevel(art.level());
 
     if (art.cursed()) {
       isCursed[i] = art.cursed().get();
@@ -149,4 +149,8 @@ void DeserializeGeneratedArtifacts(const std::vector<int> &src) {
 
 const std::vector<int> & SerializeGeneratedArtifacts() {
   return isGenerated;
+}
+
+int GetArtifactLevel(int id) {
+  return gArtifactLevel[id];
 }

--- a/src/cpp/shared/artifacts.h
+++ b/src/cpp/shared/artifacts.h
@@ -1,6 +1,8 @@
 #ifndef TIED_ARTIFACT_H
 #define TIED_ARTIFACT_H
 
+#include <vector>
+
 #define MAX_ARTIFACTS 14
 
 enum ARTIFACT {
@@ -117,6 +119,13 @@ const int NUM_SUPPORTED_ARTIFACTS = 256;
 
 void LoadArtifacts();
 int __fastcall IsCursedItem(int);
+bool IsArtifactGenerated(int);
+void GenerateArtifact(int);
+void ResetGeneratedArtifacts();
+void ResetGeneratedArtifacts(int);
+
+void DeserializeGeneratedArtifacts(const std::vector<int> &);
+const std::vector<int> & SerializeGeneratedArtifacts();
 
 extern char *gArtifactNames[];
 extern unsigned char gArtifactLevel[];

--- a/src/cpp/shared/artifacts.h
+++ b/src/cpp/shared/artifacts.h
@@ -112,6 +112,15 @@ enum ARTIFACT {
   ARTIFACT_PANDORA_BOX = 103,
 };
 
+enum ArtifactLevel {
+  ARTIFACT_LEVEL_ULTIMATE = 1,
+  ARTIFACT_LEVEL_MAJOR = 2,
+  ARTIFACT_LEVEL_MINOR = 4,
+  ARTIFACT_LEVEL_TREASURE = 8,
+  ARTIFACT_LEVEL_SPELLBOOK = 16,
+  ARTIFACT_LEVEL_UNUSED = 32
+};
+
 const int MAX_BASE_ARTIFACT = 81;
 const int MIN_EXPANSION_ARTIFACT = 86;
 const int MAX_EXPANSION_ARTIFACT = 102;
@@ -123,11 +132,11 @@ bool IsArtifactGenerated(int);
 void GenerateArtifact(int);
 void ResetGeneratedArtifacts();
 void ResetGeneratedArtifacts(int);
+int GetArtifactLevel(int);
 
 void DeserializeGeneratedArtifacts(const std::vector<int> &);
 const std::vector<int> & SerializeGeneratedArtifacts();
 
 extern char *gArtifactNames[];
-extern unsigned char gArtifactLevel[];
 
 #endif

--- a/src/cpp/shared/artifacts.h
+++ b/src/cpp/shared/artifacts.h
@@ -119,5 +119,6 @@ void LoadArtifacts();
 int __fastcall IsCursedItem(int);
 
 extern char *gArtifactNames[];
+extern unsigned char gArtifactLevel[];
 
 #endif

--- a/src/cpp/shared/game/game.cpp
+++ b/src/cpp/shared/game/game.cpp
@@ -290,7 +290,7 @@ void game::InitRandomArtifacts() {
 
 int game::GetRandomArtifactId(int allowedLevels, int allowNegatives) {
   int winConditionArtifact = -1;
-  if (mapHeader.winConditionType == WIN_FIND_ARTIFACT) {
+  if (mapHeader.winConditionType == WIN_CONDITION_FIND_ARTIFACT) {
     winConditionArtifact = mapHeader.winConditionArgumentOrLocX - 1;
   }
 
@@ -301,7 +301,8 @@ int game::GetRandomArtifactId(int allowedLevels, int allowNegatives) {
   const int numArtifacts = (xIsExpansionMap ? NUM_SUPPORTED_ARTIFACTS : MAX_BASE_ARTIFACT + 1);
 
   for (int i = 0; i < numArtifacts; ++i) {
-    if ((gArtifactLevel[i] & allowedLevels) == 0) { // TODO: also test for unused
+    const int level = GetArtifactLevel(i);
+    if ((level == ARTIFACT_LEVEL_UNUSED) || ((level & allowedLevels) == 0)) {
       continue;
     }
     if (IsArtifactGenerated(i)) {

--- a/src/cpp/shared/game/game.h
+++ b/src/cpp/shared/game/game.h
@@ -3,6 +3,7 @@
 
 #include "adventure/adv.h"
 #include "adventure/map.h"
+#include "artifacts.h"
 #include "town/town.h"
 
 #define NUM_PLAYERS 6
@@ -139,7 +140,7 @@ public:
 	char relatedToHeroForHireStatus[54];
 	mine mines[144];
 	char field_60A6[144];
-	char artifactGeneratedRandomly[103];
+	char artifactGeneratedRandomly[NUM_SUPPORTED_ARTIFACTS];
 	boat boats[48];
 	char boatBuilt[48];
 	char obeliskVisitedMasks[48];
@@ -208,7 +209,8 @@ public:
   void MakeAllWaterVisible(int player);
   void MakeAllWaterVisible_orig(int player);
 
-  int InitRandomArtifacts();
+  void InitRandomArtifacts();
+  int GetRandomArtifactId(int allowedLevels, int allowNegatives);
   int LoadMap(char *nam);
   int ProcessRandomObjects();
   int ProcessMapExtra();
@@ -271,7 +273,7 @@ extern int iLastMsgNumHumanPlayers;
 extern bool gbSetupGamePosToRealGamePos[];
 extern signed char gcColorToSetupPos[];
 extern signed char giVisRange[];
-extern char xIsPlayingExpansionCampaign;
+extern unsigned char xIsPlayingExpansionCampaign;
 extern int giCurTurn;
 extern int giMonthType;
 extern int giMonthTypeExtra;

--- a/src/cpp/shared/game/game.h
+++ b/src/cpp/shared/game/game.h
@@ -140,7 +140,7 @@ public:
 	char relatedToHeroForHireStatus[54];
 	mine mines[144];
 	char field_60A6[144];
-	char artifactGeneratedRandomly[NUM_SUPPORTED_ARTIFACTS];
+	char artifactGeneratedRandomly[103];
 	boat boats[48];
 	char boatBuilt[48];
 	char obeliskVisitedMasks[48];

--- a/src/cpp/shared/game/save.cpp
+++ b/src/cpp/shared/game/save.cpp
@@ -1,4 +1,5 @@
 #include "adventure/adv.h"
+#include "artifacts.h"
 #include "base.h"
 #include "adventure/map.h"
 #include "game/game.h"
@@ -44,13 +45,26 @@ static const LPCWSTR tmpFileNameW = L"tmp";
 
 template<typename T>
 void ReadArrayFromXML(T &dest, xsd::cxx::tree::sequence<ironfist_save::arrayInt_t> &src) {
-  for (int i = 0; i < src.size(); i++)
+  for (auto i = 0u; i < src.size(); i++)
+    dest[i] = src.at(i).value();
+}
+
+template <>
+void ReadArrayFromXML(std::vector<int> &dest, xsd::cxx::tree::sequence<ironfist_save::arrayInt_t> &src) {
+  dest.resize(src.size());
+  for (auto i = 0u; i < src.size(); i++)
     dest[i] = src.at(i).value();
 }
 
 template<typename T>
 void WriteArrayToXML(xsd::cxx::tree::sequence<ironfist_save::arrayInt_t> &dest, T &src) {
-  for (int i = 0; i < ELEMENTS_IN(src); i++)
+  for (auto i = 0u; i < ELEMENTS_IN(src); i++)
+    dest.push_back(ironfist_save::arrayInt_t::value_type(src[i]));
+}
+
+template <>
+void WriteArrayToXML(xsd::cxx::tree::sequence<ironfist_save::arrayInt_t> &dest, const std::vector<int> &src) {
+  for (auto i = 0u; i < src.size(); i++)
     dest.push_back(ironfist_save::arrayInt_t::value_type(src[i]));
 }
 
@@ -231,7 +245,10 @@ static void ReadGameStateXML(ironfist_save::gamestate_t& gs, game* gam) {
   }
 
   ReadArrayFromXML(gam->field_60A6, gs.field_60A6());
-  ReadArrayFromXML(gam->artifactGeneratedRandomly, gs.randomArtifacts());
+
+  std::vector<int> xmlArtifacts;
+  ReadArrayFromXML(xmlArtifacts, gs.randomArtifacts());
+  DeserializeGeneratedArtifacts(xmlArtifacts);
 
   for (int i = 0; i < gs.boat().size(); i++) {
     boat *bt = &gam->boats[i];
@@ -414,7 +431,7 @@ ironfist_save::gamestate_t WriteGameStateXML(game* gam) {
   WriteArrayToXML(gs.field_2773(), gam->field_2773);
   WriteArrayToXML(gs.field_27BB(), gam->field_27BB);
   WriteArrayToXML(gs.field_60A6(), gam->field_60A6);
-  WriteArrayToXML(gs.randomArtifacts(), gam->artifactGeneratedRandomly);
+  WriteArrayToXML(gs.randomArtifacts(), SerializeGeneratedArtifacts());
   WriteArrayToXML(gs.boatBuilt(), gam->boatBuilt);
   WriteArrayToXML(gs.obeliskVisitedMasks(), gam->obeliskVisitedMasks);
   WriteArrayToXML(gs.field_637D(), gam->field_637D);


### PR DESCRIPTION
Tested by placing 36 ART-3 objects on a map, counting repeats, and
making sure the game didn't crash.

Also, silenced a few more compiler warnings.