### PR TITLE
Add support for campaign-only artifacts.

### DIFF
--- a/data/artifacts.xml
+++ b/data/artifacts.xml
@@ -432,7 +432,7 @@
         <description>The Arm of the Martyr increases your spell power by 3 but adds the undead morale penalty.</description>
         <event>One of the less intelligent members of your party picks up an arm off of the ground.  Despite its missing a body, it is still moving.  Your troops find the dismembered arm repulsive, but you cannot bring yourself to drop it: it seems to hold some sort of magical power that influences your decision making.</event>
     </artifact>
-    <artifact id="88" name="Breastplate of Anduran" level="major">
+    <artifact id="88" name="Breastplate of Anduran" level="major" campaign_only="true">
         <title>Breastplate of Anduran</title>
         <description>The Breastplate increases your defense by 5.</description>
         <event>You come upon a sign.  It reads: "Here lies the body of Anduran.  Bow and swear fealty, and you shall be rewarded."  You decide to do as it says.  As you stand up, you feel a coldness against your skin.  Looking down, you find that you are suddenly wearing a gleaming, ornate breastplate.</event>
@@ -442,7 +442,7 @@
         <description>The Broach of Shielding provides 50% protection from Armageddon and Elemental Storm, but decreases spell power by 2.</description>
         <event>A kindly Sorceress thinks that your army's defenses could use a magical boost.  She offers to enchant the Broach that you wear on your cloak, and you accept.</event>
     </artifact>
-    <artifact id="90" name="Battle Garb of Anduran" level="major">
+    <artifact id="90" name="Battle Garb of Anduran" level="major" campaign_only="true">
         <title>Battle Garb</title>
         <description>The Battle Garb of Anduran combines the powers of the three Anduran artifacts.  It provides maximum luck and morale for your troops and gives you the Town Portal spell.</description>
         <event>Out of pity for a poor peasant, you purchase a chest of old junk they are hawking for too much gold. Later, as you search through it, you find it contains the 3 pieces of the legendary battle garb of Anduran!</event>
@@ -462,7 +462,7 @@
         <description>The Heart of Ice provides 50% protection from cold, but doubles the damage taken from fire.</description>
         <event>Suddenly, a biting coldness engulfs your body.  You seize up, falling from your horse.  The pain subsides, but you still feel as if your chest is frozen.  As you pick yourself up off of the ground, you hear hearty laughter.  You turn around just in time to see a Frost Giant run off into the woods and disappear.</event>
     </artifact>
-    <artifact id="94" name="Helmet of Anduran" level="major">
+    <artifact id="94" name="Helmet of Anduran" level="major" campaign_only="true">
         <title>Helmet of Anduran</title>
         <description>The Helmet increases your spell power by 5.</description>
         <event>You spy a gleaming object poking up out of the ground.   You send a member of your party over to investigate.  He comes back with a golden helmet in his hands.  You realize that it must be the helmet of the legendary Anduran, the only man who was known to wear solid gold armor.</event>
@@ -482,7 +482,7 @@
         <description>The Masthead boosts your luck and morale by 1 each in sea combat.</description>
         <event>An old seaman tells you a tale of an enchanted masthead that he used in his youth to rally his crew during times of trouble.  He then hands you a faded map that shows where he hid it.  After much exploring, you find it stashed underneath a nearby dock.</event>
     </artifact>
-    <artifact id="98" name="Sphere of Negation" level="major">
+    <artifact id="98" name="Sphere of Negation" level="major" campaign_only="true">
         <title>Sphere of Negation</title>
         <description>The Sphere of Negation disables all spell casting, for both sides, in combat.</description>
         <event>You stop to help a Peasant catch a runaway mare.  To show his gratitude, he hands you a tiny sphere.  As soon as you grasp it, you feel the magical energy drain from your limbs...</event>
@@ -497,7 +497,7 @@
         <description>The Sword Breaker increases your defense by 4 and attack by 1.</description>
         <event>A former Captain of the Guard admires your quest and gives you the enchanted Sword Breaker that he relied on during his tour of duty.</event>
     </artifact>
-    <artifact id="101" name="Sword of Anduran" level="major">
+    <artifact id="101" name="Sword of Anduran" level="major" campaign_only="true">
         <title>Sword of Anduran</title>
         <description>The Sword increases your attack skill by 5.</description>
         <event>A Troll stops you and says: "Pay me 5,000 gold, or the Sword of Anduran will slay you where you stand."  You refuse.  The troll grabs the sword hanging from its belt, screams in pain, and runs away.  Picking up the fabled sword, you give thanks that half-witted Trolls tend to grab the wrong end of sharp objects.</event>
@@ -512,7 +512,7 @@
         <description>Pandora's Box gives your hero's army a random stack of level 1 creatures for the duration of each battle.</description>
         <event>You pass by a chest lying under a tree. Suddenly, a goblin jumps out of the chest and shrieks. Before it can raise its club, you grab it and throw it back in the chest, and tie it sealed with rope.</event>
     </artifact>
-    <artifact id="104" name="Iron Fist" level="major">
+    <artifact id="104" name="Iron Fist" level="major" campaign_only="true">
         <title>Iron Fist</title>
         <description>The Iron Fist is a snazzy accessory to go with your helmet and boots.</description>
         <event>You get a sudden urge to dig where you are standing. You dig and find a glistening metal gauntlet, mysteriously untouched by dirt. As you touch it, it leaps up and fuses itself onto your arm.</event>

--- a/src/cpp/shared/artifacts.cpp
+++ b/src/cpp/shared/artifacts.cpp
@@ -7,8 +7,7 @@
 /*
  *
  * Also still unsupported:
- * 1) Random artifacts
- * 2) AI Artifact value tables
+ * 1) AI Artifact value tables
  *
  * FURTHERMORE
  *
@@ -63,6 +62,7 @@ namespace {
   std::vector<std::string> events;
   std::vector<int> isCursed;
   std::vector<int> isGenerated;
+  std::vector<int> isCampaignOnly;
 }
 
 char *gArtifactNames[NUM_SUPPORTED_ARTIFACTS] = { 0 };
@@ -80,6 +80,7 @@ void LoadArtifacts() {
   events.resize(artSize);
   isCursed.resize(artSize, 0);
   isGenerated.resize(artSize, 0);
+  isCampaignOnly.resize(artSize, 0);
 
   for (const auto &art : artifactList) {
     const int i = art.id();
@@ -107,6 +108,10 @@ void LoadArtifacts() {
     if (art.cursed()) {
       isCursed[i] = art.cursed().get();
     }
+
+    if (art.campaign_only()) {
+      isCampaignOnly[i] = art.campaign_only().get();
+    }
   }
 }
 
@@ -121,6 +126,23 @@ int __fastcall IsCursedItem(int artId) {
 
 bool IsArtifactGenerated(int id) {
   return isGenerated[id] == 1;
+}
+
+bool IsArtifactGenerationAllowed(int id) {
+  if (IsArtifactGenerated(id)) {
+    return false;
+  }
+  if (GetArtifactLevel(id) == ARTIFACT_LEVEL_UNUSED) {
+    return false;
+  }
+  if (id == ARTIFACT_SPELL_SCROLL) {  // TODO: learn how to add a random spell to these
+    return false;
+  }
+  if (isCampaignOnly[id]) {
+    return false;
+  }
+
+  return true;
 }
 
 void GenerateArtifact(int id) {

--- a/src/cpp/shared/artifacts.h
+++ b/src/cpp/shared/artifacts.h
@@ -129,6 +129,7 @@ const int NUM_SUPPORTED_ARTIFACTS = 256;
 void LoadArtifacts();
 int __fastcall IsCursedItem(int);
 bool IsArtifactGenerated(int);
+bool IsArtifactGenerationAllowed(int);
 void GenerateArtifact(int);
 void ResetGeneratedArtifacts();
 void ResetGeneratedArtifacts(int);

--- a/src/cpp/shared/artifacts_xml.cxx
+++ b/src/cpp/shared/artifacts_xml.cxx
@@ -187,6 +187,30 @@ cursed (const cursed_optional& x)
   this->cursed_ = x;
 }
 
+const artifact_t::campaign_only_optional& artifact_t::
+campaign_only () const
+{
+  return this->campaign_only_;
+}
+
+artifact_t::campaign_only_optional& artifact_t::
+campaign_only ()
+{
+  return this->campaign_only_;
+}
+
+void artifact_t::
+campaign_only (const campaign_only_type& x)
+{
+  this->campaign_only_.set (x);
+}
+
+void artifact_t::
+campaign_only (const campaign_only_optional& x)
+{
+  this->campaign_only_ = x;
+}
+
 
 // level_t
 // 
@@ -271,7 +295,8 @@ artifact_t (const id_type& id,
   id_ (id, ::xml_schema::flags (), this),
   name_ (name, ::xml_schema::flags (), this),
   level_ (level, ::xml_schema::flags (), this),
-  cursed_ (::xml_schema::flags (), this)
+  cursed_ (::xml_schema::flags (), this),
+  campaign_only_ (::xml_schema::flags (), this)
 {
 }
 
@@ -286,7 +311,8 @@ artifact_t (const artifact_t& x,
   id_ (x.id_, f, this),
   name_ (x.name_, f, this),
   level_ (x.level_, f, this),
-  cursed_ (x.cursed_, f, this)
+  cursed_ (x.cursed_, f, this),
+  campaign_only_ (x.campaign_only_, f, this)
 {
 }
 
@@ -301,7 +327,8 @@ artifact_t (const ::xercesc::DOMElement& e,
   id_ (f, this),
   name_ (f, this),
   level_ (f, this),
-  cursed_ (f, this)
+  cursed_ (f, this),
+  campaign_only_ (f, this)
 {
   if ((f & ::xml_schema::flags::base) == 0)
   {
@@ -389,6 +416,12 @@ parse (::xsd::cxx::xml::dom::parser< char >& p,
     if (n.name () == "cursed" && n.namespace_ ().empty ())
     {
       this->cursed_.set (cursed_traits::create (i, f, this));
+      continue;
+    }
+
+    if (n.name () == "campaign_only" && n.namespace_ ().empty ())
+    {
+      this->campaign_only_.set (campaign_only_traits::create (i, f, this));
       continue;
     }
   }
@@ -1101,6 +1134,18 @@ operator<< (::xercesc::DOMElement& e, const artifact_t& i)
         e));
 
     a << *i.cursed ();
+  }
+
+  // campaign_only
+  //
+  if (i.campaign_only ())
+  {
+    ::xercesc::DOMAttr& a (
+      ::xsd::cxx::xml::dom::create_attribute (
+        "campaign_only",
+        e));
+
+    a << *i.campaign_only ();
   }
 }
 

--- a/src/cpp/shared/artifacts_xml.hxx
+++ b/src/cpp/shared/artifacts_xml.hxx
@@ -384,6 +384,24 @@ class artifact_t: public ::xml_schema::type
   void
   cursed (const cursed_optional& x);
 
+  // campaign_only
+  // 
+  typedef ::xml_schema::boolean campaign_only_type;
+  typedef ::xsd::cxx::tree::optional< campaign_only_type > campaign_only_optional;
+  typedef ::xsd::cxx::tree::traits< campaign_only_type, char > campaign_only_traits;
+
+  const campaign_only_optional&
+  campaign_only () const;
+
+  campaign_only_optional&
+  campaign_only ();
+
+  void
+  campaign_only (const campaign_only_type& x);
+
+  void
+  campaign_only (const campaign_only_optional& x);
+
   // Constructors.
   //
   artifact_t (const id_type&,
@@ -420,6 +438,7 @@ class artifact_t: public ::xml_schema::type
   ::xsd::cxx::tree::one< name_type > name_;
   ::xsd::cxx::tree::one< level_type > level_;
   cursed_optional cursed_;
+  campaign_only_optional campaign_only_;
 };
 
 class level_t: public ::xml_schema::string

--- a/src/cpp/shared/game/game.cpp
+++ b/src/cpp/shared/game/game.cpp
@@ -301,22 +301,10 @@ int game::GetRandomArtifactId(int allowedLevels, int allowNegatives) {
   const int numArtifacts = (xIsExpansionMap ? NUM_SUPPORTED_ARTIFACTS : MAX_BASE_ARTIFACT + 1);
 
   for (int i = 0; i < numArtifacts; ++i) {
-    const int level = GetArtifactLevel(i);
-    if ((level == ARTIFACT_LEVEL_UNUSED) || ((level & allowedLevels) == 0)) {
+    if ((GetArtifactLevel(i) & allowedLevels) == 0) {
       continue;
     }
-    if (IsArtifactGenerated(i)) {
-      continue;
-    }
-    if (i == ARTIFACT_SPELL_SCROLL) {
-      continue;
-    }
-    if (xIsPlayingExpansionCampaign
-      && (i == ARTIFACT_BREASTPLATE_OF_ANDURAN
-       || i == ARTIFACT_BATTLE_GARB_OF_ANDURAN
-       || i == ARTIFACT_HELMET_OF_ANDURAN
-       || i == ARTIFACT_SWORD_OF_ANDURAN
-       || i == ARTIFACT_SPHERE_OF_NEGATION)) {
+    if (!IsArtifactGenerationAllowed(i)) {
       continue;
     }
     if (!allowCursed && IsCursedItem(i)) {

--- a/src/xsd/artifacts_xml.xsd
+++ b/src/xsd/artifacts_xml.xsd
@@ -19,6 +19,7 @@
         <xs:attribute name="name" type="xs:string" use="required" />
         <xs:attribute name="level" type="level_t" use="required" />
         <xs:attribute name="cursed" type="xs:boolean" use="optional" />
+        <xs:attribute name="campaign_only" type="xs:boolean" use="optional" />
     </xs:complexType>
 
     <xs:simpleType name="level_t">


### PR DESCRIPTION
Campaign-only artifacts are never randomly generated. They can only be
placed manually or given in events. I included all of the Anduran pieces,
the Sphere of Negation, and the Iron Fist in the initial set of campaign-only
artifacts.