### PR TITLE
Preventative gitignore of ironfist-install.exe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ bld/
 [Ll]og/
 [Bb]in/
 *.obj
+installer/ironfist-install.exe
 
 # Visual C++ cache files
 ipch/


### PR DESCRIPTION
This installer file is usually generated to test development builds and doesn't need to be tracked or detected by Git. When we release a new version, we will rename this file in correspondence with the new release version, so we don't have any reason to track this right now.