### PR TITLE
Fixed Crash in obelisk

### DIFF
--- a/src/asm/heroes2_imports.inc
+++ b/src/asm/heroes2_imports.inc
@@ -321,6 +321,8 @@ IMPORT_?TownQuickView@advManager@@QAEXHHHH@Z = 1
 IMPORT_?DrawCell@advManager@@QAEXHHHHHH@Z = 1
 ?DrawCell@advManager@@QAEXHHHHHH@Z_clone EQU ?DrawCell_orig@advManager@@QAEXHHHHHH@Z
 IMPORT_?DrawCursor@advManager@@QAEXXZ = 1
+IMPORT_?PuzzleDraw@advManager@@QAEXHHHH@Z = 1
+?PuzzleDraw@advManager@@QAEXHHHH@Z_clone EQU ?PuzzleDraw_orig@advManager@@QAEXHHHH@Z
 
 ;;hero movement reminder
 IMPORT_?ProcessDeSelect@advManager@@QAEHPAUtag_message@@PAHPAPAVmapCell@@@Z = 1

--- a/src/cpp/shared/adventure/adv.cpp
+++ b/src/cpp/shared/adventure/adv.cpp
@@ -1384,3 +1384,8 @@ void __fastcall GiveTakeArtifactStat(hero *h, int art, int take) {
   else
     ScriptCallback("OnArtifactTake", deepbind<hero*>(h), art);
 }
+
+// Bug fix for drawing puzzle when artifact x or y >= 128
+void advManager::PuzzleDraw(int offsetX, int offsetY, int artifactX, int artifactY) {
+  this->PuzzleDraw_orig((unsigned char)offsetX, (unsigned char)offsetY, (unsigned char)artifactX, (unsigned char)artifactY);
+}

--- a/src/cpp/shared/adventure/adv.h
+++ b/src/cpp/shared/adventure/adv.h
@@ -341,6 +341,8 @@ public:
   void GetCursorSampleSet(int speed);
   void DisableButtons();
   void EnableButtons();
+  void PuzzleDraw(int offsetX, int offsetY, int artifactX, int artifactY);
+  void PuzzleDraw_orig(int offsetX, int offsetY, int artifactX, int artifactY);
 };
 
 extern advManager* gpAdvManager;


### PR DESCRIPTION
Obelisk artifact location is stored in two char fields. Values there become negative if their coordinates are bigger than 127. advManager::PuzzleDraw on the other hand receives those coordinates as int type. So I just put a cast on char values to unsigned char before they are passed.